### PR TITLE
Add support for Kernel 4.15, which changed the timer interface.

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4724,7 +4724,11 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 	source = rtw_zmalloc(2048);
 
 	if (source != NULL) {
-		len = vfs_read(fp, source, len, &pos);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+                len = kernel_read(fp, source, len, &pos);
+#else
+                len = vfs_read(fp, source, len, &pos);
+#endif
 		rtw_parse_cipher_list(nlo_info, source);
 		rtw_mfree(source, 2048);
 	}

--- a/hal/phydm/phydm_types.h
+++ b/hal/phydm/phydm_types.h
@@ -153,8 +153,12 @@ typedef enum _RT_SPINLOCK_TYPE{
 
 	typedef struct rtl8192cd_priv	*prtl8192cd_priv;
 	typedef struct stat_info		STA_INFO_T,*PSTA_INFO_T;
-	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
-	typedef  void *				RT_TIMER_CALL_BACK;
+#if defined (LINUX_VERSION_CODE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        typedef struct legacy_timer_emu		RT_TIMER, *PRT_TIMER;
+#else
+        typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
+        typedef  void *				RT_TIMER_CALL_BACK;
 
 #ifdef CONFIG_PCI_HCI
 	#define DEV_BUS_TYPE		RT_PCI_INTERFACE
@@ -223,8 +227,12 @@ typedef enum _RT_SPINLOCK_TYPE{
 		#define	ODM_ENDIAN_TYPE			ODM_ENDIAN_BIG
 	#endif
 	
-	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
-	typedef  void *				RT_TIMER_CALL_BACK;
+#if defined (LINUX_VERSION_CODE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        typedef struct legacy_timer_emu		RT_TIMER, *PRT_TIMER;
+#else
+        typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
+        typedef  void *				RT_TIMER_CALL_BACK;
 	#define	STA_INFO_T			struct sta_info
 	#define	PSTA_INFO_T		struct sta_info *
 		

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -321,7 +321,11 @@ extern void rtw_init_timer(_timer *ptimer, void *padapter, void *pfunc);
 __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 {
 #ifdef PLATFORM_LINUX
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        return del_timer_sync(&ptimer->t);
+#else
 	return del_timer_sync(ptimer);
+#endif
 #endif
 #ifdef PLATFORM_FREEBSD
 	_cancel_timer(ptimer, 0);

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -138,7 +138,15 @@ typedef struct mutex		_mutex;
 #else
 typedef struct semaphore	_mutex;
 #endif
-typedef struct timer_list _timer;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        typedef struct legacy_timer_emu {
+                struct timer_list t;
+                void (*function)(unsigned long);
+                unsigned long data;
+        } _timer;
+ #else
+        typedef struct timer_list _timer;
+ #endif
 
 struct	__queue	{
 	struct	list_head	queue;
@@ -255,23 +263,43 @@ __inline static void rtw_list_delete(_list *plist) {
 }
 
 #define RTW_TIMER_HDL_ARGS void *FunctionContext
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+ static void legacy_timer_emu_func(struct timer_list *t)
+ {
+        struct legacy_timer_emu *lt = from_timer(lt, t, t);
+        lt->function(lt->data);
+ }
+ #endif
 
 __inline static void _init_timer(_timer *ptimer, _nic_hdl nic_hdl, void *pfunc, void *cntx) {
 	/* setup_timer(ptimer, pfunc,(u32)cntx);	 */
 	ptimer->function = pfunc;
 	ptimer->data = (unsigned long)cntx;
-	init_timer(ptimer);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        timer_setup(&ptimer->t, legacy_timer_emu_func, 0);
+ #else
+        init_timer(ptimer);
+ #endif
 }
 
-__inline static void _set_timer(_timer *ptimer, u32 delay_time) {
-	mod_timer(ptimer , (jiffies + (delay_time * HZ / 1000)));
-}
+__inline static void _set_timer(_timer *ptimer, u32 delay_time)
+ {
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        mod_timer(&ptimer->t, (jiffies+(delay_time*HZ/1000)));
+ #else
+        mod_timer(ptimer , (jiffies + (delay_time * HZ / 1000)));
+ #endif
+ }
 
-__inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled) {
-	del_timer_sync(ptimer);
-	*bcancelled = 1;
-}
-
+ __inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled)
+ {
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+        del_timer_sync(&ptimer->t);
+ #else
+        del_timer_sync(ptimer);
+ #endif
+        *bcancelled = 1;
+ }
 
 static inline void _init_workitem(_workitem *pwork, void *pfunc, void *cntx) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20))

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1960,8 +1960,10 @@ static int readFile(struct file *fp, char *buf, int len)
 		return -EPERM;
 
 	while (sum < len) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
-		rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0))
+                rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+                rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
 #else
 		rlen = fp->f_op->read(fp, buf + sum, len - sum, &fp->f_pos);
 #endif


### PR DESCRIPTION
Worked for me.
Added from https://github.com/aircrack-ng/rtl8812au/commit/f221a169f281dab9756a176ec2abd91e0eba7d19

Thanks.