### PR TITLE
Fixes for Linux 4.19

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1002,8 +1002,9 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
-
+#endif
 
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1042,14 +1042,16 @@ unsigned int rtw_classify8021d(struct sk_buff *skb) {
 
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0))
+			    ,struct net_device *sb_dev
+			    ,select_queue_fallback_t fallback
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
+                            , select_queue_fallback_t fallback			    
+#elif (LINUX_VERSION_CODE == KERNEL_VERSION(3, 13, 0))
                             , void *accel_priv
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
-                            , select_queue_fallback_t fallback
 #endif
-
-#endif
-                           ) {
+) 
+{
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 


### PR DESCRIPTION
Fixes for Kernel v4.19 that will allow it to install properly without error and warnings.