### PR TITLE
Restore previous rtw_select_queue for Linux < 4.19

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1042,16 +1042,18 @@ unsigned int rtw_classify8021d(struct sk_buff *skb) {
 
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0))
-			    ,struct net_device *sb_dev
-			    ,select_queue_fallback_t fallback
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
-                            , select_queue_fallback_t fallback			    
-#elif (LINUX_VERSION_CODE == KERNEL_VERSION(3, 13, 0))
+                            , struct net_device *accel_priv
+#else
                             , void *accel_priv
 #endif
-) 
-{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+                            , select_queue_fallback_t fallback
+#endif
+
+#endif
+                           ) {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 


### PR DESCRIPTION
I tried to compile rtl8822bu on the current Linux Mint. This distribution uses kernel 4.15.0. The build failed in os_dep/linux/os_intfs.c because rtw_select_queue did not match the structure field it was assigned to. The problem seems to be the recent change for kernel 4.19.

This pull request restores the previous type for rtw_select_queue if the kernel is less than 4.19.