### PR TITLE
No issue/ticket.

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1046,6 +1046,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 			    ,struct net_device *sb_dev
 			    ,select_queue_fallback_t fallback
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
+                            , void *accel_priv
                             , select_queue_fallback_t fallback			    
 #elif (LINUX_VERSION_CODE == KERNEL_VERSION(3, 13, 0))
                             , void *accel_priv


### PR DESCRIPTION
Align rtw_select_queue with ndo_select_queue definition for Linux version >= v3.14 < v4.18.
One parameter was dropped which causes a compile time error on Fedora 29.