### PR TITLE
get_monotonic_boottime is deprecated

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -322,7 +322,9 @@ static const struct ieee80211_txrx_stypes
 
 static u64 rtw_get_systime_us(void) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0))
-	return ktime_get_boottime();
+	struct timespec64 ts;
+	ktime_get_boottime_ts64(&ts);
+	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -321,7 +321,9 @@ static const struct ieee80211_txrx_stypes
 #endif
 
 static u64 rtw_get_systime_us(void) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0))
+	return ktime_get_boottime();
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);
 	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;


### PR DESCRIPTION
get_monotonic_boottime seems to have been removed from the Linux kernel recently, so this was my attempt at updating it to use ktime functions instead.

Linux 3.17 seems to be when the function was made deprecated.
https://www.systutorials.com/linux-kernels/518203/timekeeping-use-ktime_get_boottime-for-get_monotonic_boottime-linux-3-17/