### PR TITLE
access_ok macro only accepts 2 parameters instead of 3 in Linux kernel 5.0

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -604,7 +604,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd) {
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+#endif
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
After updating my system, the driver failed to compile until I removed the VERIFY_READ in the android.c file. This appears to be due to a recent change to access_ok.

https://www.kernel.org/doc/html/latest/core-api/mm-api.html#c.access_ok
https://github.com/zfsonlinux/zfs/commit/2f108d7423f43d926573849dfc4223641e2fa9c0