### PR TITLE
rtw_select_queue signature change in linux-5.2

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1040,7 +1040,6 @@ unsigned int rtw_classify8021d(struct sk_buff *skb) {
 	return dscp >> 5;
 }
 
-
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0))
@@ -1048,7 +1047,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #else
                             , void *accel_priv
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0))
                             , select_queue_fallback_t fallback
 #endif
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2017,7 +2017,7 @@ static int isFileReadable(char *path)
 		ret = PTR_ERR(fp);
 	else {
 		oldfs = get_fs();
-		set_fs(get_ds());
+		set_fs(KERNEL_DS);
 
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
@@ -2047,7 +2047,7 @@ static int retriveFromFile(char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = readFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);
@@ -2082,7 +2082,7 @@ static int storeToFile(char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = writeFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);


### PR DESCRIPTION
Ref: torvalds/linux@b71b583

I tested it in the following environment.
- 5.2.18-100.fc29.x86_64
- Fedora release 29 (Twenty Nine)